### PR TITLE
Expose hub for bridge to tlh

### DIFF
--- a/ce.patch
+++ b/ce.patch
@@ -143,3 +143,17 @@ index 6c213a16..9b7edc0e 100644
        ul#motd.navbar-nav.navbar-center.mr-auto.community-advert.d-none
          span.content
            | Thanks for using Compiler Explorer
+diff --git a/static/main.js b/static/main.js
+index 7f7a036f..1798b4e5 100644
+--- a/static/main.js
++++ b/static/main.js
+@@ -504,6 +504,9 @@ function start() {
+         hub = new Hub(layout, subLangId, defaultLangId);
+     }
+
++    // Expose the hub for the tlh bridge.
++    window.hub = hub;
++
+     if (hub.hasTree()) {
+         $('#add-tree').prop('disabled', true);
+     }


### PR DESCRIPTION
This allows to easier access the monaco editor models and also allows to access the monaco editors needed to get the currently selected text in https://github.com/octorock/the-little-hat/commit/da11d03efcccecb133ca46b766976301da849df9#diff-ae70628605c3141780efb4e55bb32e971a06485ff9af2e15b61df11048dc9c78R158